### PR TITLE
feat: text sizing fix

### DIFF
--- a/src/components/sections/GlitchStatsSection.tsx
+++ b/src/components/sections/GlitchStatsSection.tsx
@@ -239,7 +239,7 @@ export default function GlitchStatsSection({
       )}
 
       {/* Text content with glitch effects */}
-      <div className="relative z-30 max-w-4xl text-center glitch-content">
+      <div className="relative z-30 text-center glitch-content">
         <h2
           ref={titleRef}
           className={`glitch-title font-heading text-8xl md:text-[10.942rem] lg:text-[17.942rem] font-bold text-gray-100 leading-tight tracking-tight`}

--- a/src/components/sections/TerminalStatsSection.tsx
+++ b/src/components/sections/TerminalStatsSection.tsx
@@ -225,7 +225,7 @@ export default function TerminalStatsSection({
       </div>
 
       {/* Text content */}
-      <div className="relative z-30 max-w-4xl text-center terminal-content">
+      <div className="relative z-30 text-center terminal-content">
         <div className="relative inline-block">
           <h2 className="stats-title font-heading text-8xl md:text-[10.942rem] lg:text-[17.942rem] font-bold text-gray-100 leading-tight tracking-tight">
             {title}


### PR DESCRIPTION
# Corrección simple
Se elimino el limite de tamaño que causaba overflow del texto.